### PR TITLE
Fixes labelling of IP Addresses - public vs private 

### DIFF
--- a/lib/openstack/compute/address.rb
+++ b/lib/openstack/compute/address.rb
@@ -1,3 +1,4 @@
+require 'ipaddr'
 module OpenStack
 module Compute
 
@@ -33,6 +34,34 @@ module Compute
         @version = version
       end
     end
+
+    NON_ROUTABLE_ADDRESSES = [IPAddr.new("10.0.0.0/8"), IPAddr.new("192.168.0.0/16"), IPAddr.new("172.16.0.0/12")]
+
+    def self.is_private?(address_string)
+      NON_ROUTABLE_ADDRESSES.each do |no_route|
+        return true if no_route.include?(address_string)
+      end
+      false
+    end
+
+    #IN:  { "private"=> [{"addr"=>"10.7.206.171", "version"=>4}, {"addr"=>"15.185.160.208", "version"=>4}]}
+    #OUT: { "private"=> [{"addr"=>"10.7.206.171", "version"=>4}],
+    #       "public"=>  [{"addr"=>"15.185.160.208", "version"=>4}] }
+    def self.fix_labels(addresses_info)
+      addresses_info.inject({"public"=>[], "private"=>[]}) do |res, (label,address_struct_list)|
+        address_struct_list.each do |address_struct|
+          if(address_struct["version"==6])#v6 addresses are all routable...
+            res["public"] << address_struct
+          else
+            is_private?(address_struct["addr"])? res["private"] << address_struct : res["public"] << address_struct
+          end
+        end
+        res
+      end
+    end
+
+
+
   end
 
 end

--- a/lib/openstack/compute/connection.rb
+++ b/lib/openstack/compute/connection.rb
@@ -63,7 +63,11 @@ module Compute
       path = OpenStack.paginate(options).empty? ? "#{@connection.service_path}/servers/detail" : "#{@connection.service_path}/servers/detail?#{OpenStack.paginate(options)}"
       response = @connection.csreq("GET",@connection.service_host,path,@connection.service_port,@connection.service_scheme)
       OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
-      OpenStack.symbolize_keys(JSON.parse(response.body)["servers"])
+      json_server_list = JSON.parse(response.body)["servers"]
+      json_server_list.each do |server|
+        server["addresses"] = OpenStack::Compute::Address.fix_labels(server["addresses"])
+      end
+      OpenStack.symbolize_keys(json_server_list)
     end
     alias :servers_detail :list_servers_detail
 

--- a/lib/openstack/compute/server.rb
+++ b/lib/openstack/compute/server.rb
@@ -234,6 +234,7 @@ module Compute
     end
 
     def get_addresses(address_info)
+      address_info = OpenStack::Compute::Address.fix_labels(address_info)
       address_list = OpenStack::Compute::AddressList.new
       address_info.each do |label, addr|
         addr.each do |address|


### PR DESCRIPTION
Current version of OS API isn't clear about distinguishing 'public' and 'private' addresses - see [this post](https://answers.launchpad.net/nova/+question/185110). The terms 'public' and 'private' are used to refer to network names, rather than the address type. 

This results in no clear way to distinguish a server's IP addresses (routable/public vs non_routable/private) through the API, as [explained here](http://www.mail-archive.com/openstack@lists.launchpad.net/msg12987.html).

Other bindings, such as hp-fog - [grab the first address](https://github.com/fog/fog/blob/master/lib/fog/hp/requests/compute/list_server_private_addresses.rb#L24) as 'private' and the rest are 'public'. As I can't find this ordering documented anywhere I feel a safer approach is to use pattern matching against 10.0.0.0/8 192.168.0.0/16, 172.16.0.0/12 to determine 'private' addresses - as in the attached commits,

marios
