### PR TITLE
Keep only greatest api version.

### DIFF
--- a/lib/openstack/connection.rb
+++ b/lib/openstack/connection.rb
@@ -292,8 +292,8 @@ class AuthV20
           else
             # There is a possibility for some services to run on different api versions. We will keep only the greatest. 
             if connection.service_path
-              current_ver = connection.service_path.match(/\/v(\d).(\d)/).captures.to_s.to_i
-              parsed_ver = @uri.to_s.match(/\/v(\d).(\d)/).captures.to_s.to_i
+              current_ver = connection.service_path.match(/\/v(\d).(\d)/).captures.inject("",:+).to_i
+              parsed_ver = @uri.path.match(/\/v(\d).(\d)/).captures.inject("",:+).to_i
 
               if current_ver > parsed_ver
                 next


### PR DESCRIPTION
There is a possibility for some services (e.g. Nova) to run on
different api versions. With this patch we will keep only the greatest
version.

Example:

{
    "access": {
        "serviceCatalog": [
            {
                "endpoints": [
                    {
                        "adminURL": "http://localhost:8774/v1.1/7", 
                        "internalURL": "http://localhost:8774/v1.1/7", 
                        "publicURL": "http://localhost:8774/v1.1/7", 
                        "region": "RegionOne"
                    }
                ], 
                "name": "nova", 
                "type": "compute"
            }, 
            {
                "endpoints": [
                    {
                        "adminURL": "http://localhost:8774/v1.0", 
                        "internalURL": "http://localhost:8774/v1.0", 
                        "publicURL": "http://localhost:8774/v1.0", 
                        "region": "RegionOne"
                    }
                ], 
                "name": "nova_compat", 
                "type": "compute"
            }
        ]
    }
}

In previews version, the gem was keeping the second option, and it was not working properly.
With this patch the host path is now pointing to v1.1
