### PR TITLE
Check service_name of endpoints against service_name, if any, provided in constructor

### DIFF
--- a/lib/openstack/connection.rb
+++ b/lib/openstack/connection.rb
@@ -280,7 +280,12 @@ class AuthV20
       raise OpenStack::Exception::NotImplemented.new("The requested service: \"#{connection.service_type}\" is not present " +
         "in the returned service catalogue.", 501, "#{resp_data["access"]["serviceCatalog"]}") unless implemented_services.include?(connection.service_type)
       resp_data['access']['serviceCatalog'].each do |service|
-        if service['type'] == connection.service_type
+          if connection.service_name
+            check_service_name = connection.service_name
+          else
+            check_service_name = service['name']
+          end
+          if service['type'] == connection.service_type and service['name'] == check_service_name
           endpoints = service["endpoints"]
           if connection.region
             endpoints.each do |ep|


### PR DESCRIPTION
The original code from ruby-openstack-compute checked the response
data to ensure that selection of the appropriate endpoint was
based on the service_name provided to the constructor if it was
actually provided.

This logic is necessary in order to work with the Rackspace
implementation of Openstack.  It returns 3 'compute' endpoints.
If you also specify the region, the first 'compute' endpoint
returned will cause an exception to be raised.
