### PR TITLE
Grab image_id from response when creating image from server

### DIFF
--- a/lib/openstack/compute/server.rb
+++ b/lib/openstack/compute/server.rb
@@ -179,7 +179,7 @@ module Compute
       data = JSON.generate(:createImage => options)
       response = @compute.connection.csreq("POST",@svrmgmthost,"#{@svrmgmtpath}/servers/#{URI.encode(self.id.to_s)}/action",@svrmgmtport,@svrmgmtscheme,{'content-type' => 'application/json'},data)
       OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
-      image_id = response["Location"].scan(/.*\/(.*)/).flatten
+      image_id = response["Location"].split("/images/").last
       OpenStack::Compute::Image.new(@compute, image_id)
     end
 


### PR DESCRIPTION
This bug was uncovered by Ronelle Landy against the [Apache Deltacloud](http://deltacloud.apache.org) project - filed as a [JIRA ticket](https://issues.apache.org/jira/browse/DTACLOUD-450)

The image_id isn't being grabbed correctly from the response

thanks, marios
