### PR TITLE
Set Content-Length to 0 for container PUT request

### DIFF
--- a/lib/openstack/connection.rb
+++ b/lib/openstack/connection.rb
@@ -188,6 +188,9 @@ class Connection
       data     = options[:data]
       attempts = options[:attempts] || 0
       path = @service_path + path
+      if method == 'PUT' and data.nil?
+        headers['Content-Length'] = "0"
+      end
       res = csreq(method,server,path,port,scheme,headers,data,attempts)
       if not res.code.match(/^20.$/)
         OpenStack::Exception.raise_exception(res)


### PR DESCRIPTION
We use nginx in front of swift, and os.create_container is hanging
forever waiting for the PUT body.

This PR is a naive fix, it might need more thought than this.
