### PR TITLE
Add method to update nova security group.

### DIFF
--- a/lib/openstack/compute/connection.rb
+++ b/lib/openstack/compute/connection.rb
@@ -364,6 +364,14 @@ module Compute
       {res[:security_group][:id].to_s => res[:security_group]}
     end
 
+    def update_security_group(id, name, description)
+      raise OpenStack::Exception::NotImplemented.new("os-security-groups not implemented by #{@connection.http.keys.first}", 501, "NOT IMPLEMENTED") unless api_extensions[:"os-security-groups"] or api_extensions[:security_groups]
+      data = JSON.generate(:security_group => { "name" => name, "description" => description})
+      response = @connection.req("PUT", "/os-security-groups/#{id}", {:data => data})
+      res = OpenStack.symbolize_keys(JSON.parse(response.body))
+      {res[:security_group][:id].to_s => res[:security_group]}
+    end
+
     def delete_security_group(id)
       raise OpenStack::Exception::NotImplemented.new("os-security-groups not implemented by #{@connection.http.keys.first}", 501, "NOT IMPLEMENTED") unless api_extensions[:"os-security-groups"] or api_extensions[:security_groups]
       response = @connection.req("DELETE", "/os-security-groups/#{id}")


### PR DESCRIPTION
Nova security group update method was not documented long time,
accordingly to https://bugs.launchpad.net/openstack-api-site/+bug/1394238,
but openstack 'nova' cli utility have that functionality and we
really use it from time to time. So I add that according method to
ruby-openstack.