### PR TITLE
add method for force_delete

### DIFF
--- a/lib/openstack/compute/server.rb
+++ b/lib/openstack/compute/server.rb
@@ -154,8 +154,11 @@ module Compute
       true
     end
 
-    # Force-deletes a server before deferred cleanup.
+    # Policy defaults enable only users with the administrative role or
+    # the owner of the server to perform this operation.
+    # Cloud providers can change these permissions through the policy.json file.
     #
+    # Force-deletes a server before deferred cleanup.
     # Returns true if the API call succeeds.
     #
     #   >> server.force_delete!
@@ -362,6 +365,10 @@ module Compute
       true
     end
 
+    # Policy defaults enable only users with the administrative role or
+    # the owner of the server to perform this operation.
+    # Cloud providers can change these permissions through the policy.json file.
+    #
     # Sends an API request to lock this server.
     #
     # Returns true if the API call succeeds.
@@ -375,6 +382,10 @@ module Compute
       true
     end
 
+    # Policy defaults enable only users with the administrative role or
+    # the owner of the server to perform this operation.
+    # Cloud providers can change these permissions through the policy.json file.
+    #
     # Sends an API request to unlock this server.
     #
     # Returns true if the API call succeeds.

--- a/lib/openstack/compute/server.rb
+++ b/lib/openstack/compute/server.rb
@@ -109,7 +109,7 @@ module Compute
       OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
       true
     end
-    
+
     # Sends an API request to start (resume) the server.
     #
     # Returns true if the API call succeeds.
@@ -150,6 +150,19 @@ module Compute
     #   => true
     def delete!
       response = @compute.connection.csreq("DELETE",@svrmgmthost,"#{@svrmgmtpath}/servers/#{URI.encode(self.id.to_s)}",@svrmgmtport,@svrmgmtscheme)
+      OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
+      true
+    end
+
+    # Force-deletes a server before deferred cleanup.
+    #
+    # Returns true if the API call succeeds.
+    #
+    #   >> server.force_delete!
+    #   => true
+    def force_delete!
+      data = JSON.generate(:forceDelete => nil)
+      response = @compute.connection.csreq("POST",@svrmgmthost,"#{@svrmgmtpath}/servers/#{URI.encode(self.id.to_s)}/action",@svrmgmtport,@svrmgmtscheme,{'content-type' => 'application/json'},data)
       OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
       true
     end

--- a/lib/openstack/compute/server.rb
+++ b/lib/openstack/compute/server.rb
@@ -362,6 +362,32 @@ module Compute
       true
     end
 
+    # Sends an API request to lock this server.
+    #
+    # Returns true if the API call succeeds.
+    #
+    #   >> server.lock
+    #   => true
+    def lock
+      data = JSON.generate(:lock => nil)
+      response = @compute.connection.csreq("POST",@svrmgmthost,"#{@svrmgmtpath}/servers/#{URI.encode(self.id.to_s)}/action",@svrmgmtport,@svrmgmtscheme,{'content-type' => 'application/json'},data)
+      OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
+      true
+    end
+
+    # Sends an API request to unlock this server.
+    #
+    # Returns true if the API call succeeds.
+    #
+    #   >> server.unlock
+    #   => true
+    def unlock
+      data = JSON.generate(:unlock => nil)
+      response = @compute.connection.csreq("POST",@svrmgmthost,"#{@svrmgmtpath}/servers/#{URI.encode(self.id.to_s)}/action",@svrmgmtport,@svrmgmtscheme,{'content-type' => 'application/json'},data)
+      OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
+      true
+    end
+
   end
 end
 end

--- a/lib/openstack/volume/connection.rb
+++ b/lib/openstack/volume/connection.rb
@@ -35,7 +35,7 @@ module Volume
 
     #no options documented in API at Nov 2012
     #(e.g. like limit/marker as used in Nova for servers)
-    #You can also provide :limit and :offset parameters to handle pagenation.
+    #You can also provide :limit and :offset :display_name parameters to handle pagenation.
     def list_volumes(options= {})
       path = options.empty? ? "/#{@volume_path}" : "/#{@volume_path}?#{options.to_query}"
       response = @connection.req("GET", path)
@@ -51,7 +51,7 @@ module Volume
     end
     alias :volume :get_volume
 
-    # You can also provide :limit and :offset parameters to handle pagenation.
+    # You can also provide :limit and :offset :display_name and :status parameters to handle pagenation.
     def list_volumes_detail(options= {})
       path = options.empty? ? "/#{@volume_path}/detail" : "/#{@volume_path}/detail?#{options.to_query}"
       response = @connection.req("GET", path)

--- a/test/unit/servers_test.rb
+++ b/test/unit/servers_test.rb
@@ -200,16 +200,7 @@ class ServersTest < Test::Unit::TestCase
 
 private
   def get_test_server
-    json_response = get_test_server_json_response
-
-    response = mock()
-    response.stubs(:code => "200", :body => json_response)
-    @comp.connection.stubs(:csreq).returns(response)
-    return @comp.server(1234)
-  end
-
-  def get_test_server_json_response
-    %{{
+    json_response = %{{
       "server" : {
           "id" : 1234,
           "name" : "sample-server",
@@ -233,6 +224,11 @@ private
           }
       }
     }}
+
+    response = mock()
+    response.stubs(:code => "200", :body => json_response)
+    @comp.connection.stubs(:csreq).returns(response)
+    return @comp.server(1234)
   end
 
   def list_servers

--- a/test/unit/servers_test.rb
+++ b/test/unit/servers_test.rb
@@ -98,6 +98,14 @@ class ServersTest < Test::Unit::TestCase
     assert_equal "10.176.42.16", server.addresses[:private][0].address
   end
 
+  def test_force_delete!
+    response = mock()
+    response.stubs(:code => "202")
+    @comp.connection.stubs(:csreq).returns(response)
+    result = get_test_server.force_delete!
+    assert_equal result, true
+  end
+
   def test_rebuild_server
     json_response = %{{
     "server": {
@@ -192,7 +200,16 @@ class ServersTest < Test::Unit::TestCase
 
 private
   def get_test_server
-    json_response = %{{
+    json_response = get_test_server_json_response
+
+    response = mock()
+    response.stubs(:code => "200", :body => json_response)
+    @comp.connection.stubs(:csreq).returns(response)
+    return @comp.server(1234)
+  end
+
+  def get_test_server_json_response
+    %{{
       "server" : {
           "id" : 1234,
           "name" : "sample-server",
@@ -216,11 +233,6 @@ private
           }
       }
     }}
-
-    response = mock()
-    response.stubs(:code => "200", :body => json_response)
-    @comp.connection.stubs(:csreq).returns(response)
-    return @comp.server(1234)
   end
 
   def list_servers

--- a/test/unit/servers_test.rb
+++ b/test/unit/servers_test.rb
@@ -106,6 +106,22 @@ class ServersTest < Test::Unit::TestCase
     assert_equal result, true
   end
 
+  def test_lock
+    response = mock()
+    response.stubs(:code => "202")
+    @comp.connection.stubs(:csreq).returns(response)
+    result = get_test_server.lock
+    assert_equal result, true
+  end
+
+  def test_unlock
+    response = mock()
+    response.stubs(:code => "202")
+    @comp.connection.stubs(:csreq).returns(response)
+    result = get_test_server.unlock
+    assert_equal result, true
+  end
+
   def test_rebuild_server
     json_response = %{{
     "server": {

--- a/test/unit/volume_connection_test.rb
+++ b/test/unit/volume_connection_test.rb
@@ -94,28 +94,17 @@ class VolumeConnectionTest < Test::Unit::TestCase
     json_response = %{{
       "volumes": [
         {
-            "id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
-            "display_name": "vol-001",
-            "display_description": "Another volume.",
-            "status": "active",
-            "size": 30,
-            "volume_type": "289da7f8-6440-407c-9fb4-7db01ec49164",
-            "metadata": {
-                "contents": "junk"
-            },
-            "availability_zone": "us-east1",
-            "snapshot_id": null,
-            "attachments": [
-                {
-                    "attachment_id": "03987cd1-0ad5-40d1-9b2a-7cc48295d4fa",
-                    "id": "47e9ecc5-4045-4ee3-9a4b-d859d546a0cf",
-                    "volume_id": "6c80f8ac-e3e2-480c-8e6e-f1db92fe4bfe",
-                    "server_id": "d1c4788b-9435-42e2-9b81-29f3be1cd01f",
-                    "host_name": "mitaka",
-                    "device": "/"
-                }
-            ],
-            "created_at": "2012-02-14T20:53:07Z"
+          "id": "45baf976-c20a-4894-a7c3-c94b7376bf55",
+          "display_name": "vol-001",
+          "display_description": null,
+          "size": 10,
+          "volume_type": null,
+          "metadata": null,
+          "availability_zone": null,
+          "snapshot_id": null,
+          "attachments": [],
+          "created_at": "2016-04-12T11:31:46.000000",
+          "status": "in-use"
         }
       ]
     }}
@@ -125,10 +114,18 @@ class VolumeConnectionTest < Test::Unit::TestCase
     @cinder.connection.stubs(:req).returns(response)
 
     volumes = @cinder.list_volumes(limit: 1)
-    assert_equal volumes.size , 1
-    assert_equal volumes[0].id, '521752a6-acf6-4b2d-bc7a-119f9148cd8c'
+    assert_equal volumes[0].size , 10
+    assert_equal volumes[0].id, '45baf976-c20a-4894-a7c3-c94b7376bf55'
     assert_equal volumes[0].display_name, 'vol-001'
-    assert_equal volumes[0].status, 'active'
+    assert_equal volumes[0].display_description, nil
+    assert_equal volumes[0].size, 10
+    assert_equal volumes[0].volume_type, nil
+    assert_equal volumes[0].metadata, nil
+    assert_equal volumes[0].availability_zone, nil
+    assert_equal volumes[0].snapshot_id, nil
+    assert_equal volumes[0].attachments, []
+    assert_equal volumes[0].created_at, "2016-04-12T11:31:46.000000"
+    assert_equal volumes[0].status, "in-use"
   end
 
   def test_list_volumes_detail

--- a/test/unit/volume_connection_test.rb
+++ b/test/unit/volume_connection_test.rb
@@ -95,16 +95,17 @@ class VolumeConnectionTest < Test::Unit::TestCase
       "volumes": [
         {
           "id": "45baf976-c20a-4894-a7c3-c94b7376bf55",
-          "display_name": "vol-001",
-          "display_description": null,
-          "size": 10,
-          "volume_type": null,
-          "metadata": null,
-          "availability_zone": null,
-          "snapshot_id": null,
-          "attachments": [],
-          "created_at": "2016-04-12T11:31:46.000000",
-          "status": "in-use"
+          "links": [
+            {
+              "href": "http://localhost:8776/v2/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/45baf976-c20a-4894-a7c3-c94b7376bf55",
+              "rel": "self"
+            },
+            {
+              "href": "http://localhost:8776/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/45baf976-c20a-4894-a7c3-c94b7376bf55",
+              "rel": "bookmark"
+            }
+          ],
+          "name": "vol-001"
         }
       ]
     }}
@@ -114,71 +115,61 @@ class VolumeConnectionTest < Test::Unit::TestCase
     @cinder.connection.stubs(:req).returns(response)
 
     volumes = @cinder.list_volumes(limit: 1)
-    assert_equal volumes[0].size , 10
     assert_equal volumes[0].id, '45baf976-c20a-4894-a7c3-c94b7376bf55'
-    assert_equal volumes[0].display_name, 'vol-001'
-    assert_equal volumes[0].display_description, nil
-    assert_equal volumes[0].size, 10
-    assert_equal volumes[0].volume_type, nil
-    assert_equal volumes[0].metadata, nil
-    assert_equal volumes[0].availability_zone, nil
-    assert_equal volumes[0].snapshot_id, nil
-    assert_equal volumes[0].attachments, []
-    assert_equal volumes[0].created_at, "2016-04-12T11:31:46.000000"
-    assert_equal volumes[0].status, "in-use"
+    assert_equal volumes.size , 1
   end
 
   def test_list_volumes_detail
     json_response = %{{
       "volumes": [
         {
-            "migration_status": null,
-            "attachments": [
-                {
-                    "server_id": "f4fda93b-06e0-4743-8117-bc8bcecd651b",
-                    "attachment_id": "3b4db356-253d-4fab-bfa0-e3626c0b8405",
-                    "host_name": null,
-                    "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
-                    "device": "/dev/vdb",
-                    "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38"
-                }
-            ],
-            "links": [
-                {
-                    "href": "http://23.253.248.171:8776/v2/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
-                    "rel": "self"
-                },
-                {
-                    "href": "http://23.253.248.171:8776/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
-                    "rel": "bookmark"
-                }
-            ],
-            "availability_zone": "nova",
-            "os-vol-host-attr:host": "difleming@lvmdriver-1#lvmdriver-1",
-            "encrypted": false,
-            "os-volume-replication:extended_status": null,
-            "replication_status": "disabled",
-            "snapshot_id": null,
-            "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
-            "size": 2,
-            "user_id": "32779452fcd34ae1a53a797ac8a1e064",
-            "os-vol-tenant-attr:tenant_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
-            "os-vol-mig-status-attr:migstat": null,
-            "metadata": {
-                "readonly": "False",
-                "attached_mode": "rw"
+          "migration_status": null,
+          "attachments": [
+            {
+              "server_id": "f4fda93b-06e0-4743-8117-bc8bcecd651b",
+              "attachment_id": "3b4db356-253d-4fab-bfa0-e3626c0b8405",
+              "host_name": null,
+              "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+              "device": "/dev/vdb",
+              "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38"
+            }
+          ],
+          "links": [
+            {
+              "href": "http://23.253.248.171:8776/v2/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+              "rel": "self"
             },
-            "status": "in-use",
-            "description": null,
-            "multiattach": true,
-            "os-volume-replication:driver_data": null,
-            "source_volid": null,
-            "consistencygroup_id": null,
-            "os-vol-mig-status-attr:name_id": null,
-            "name": "test-volume-attachments",
-            "bootable": "false",
-            "created_at": "2015-11-29T03:01:44.000000",
-            "volume_type": "lvmdriver-1"
+            {
+              "href": "http://23.253.248.171:8776/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+              "rel": "bookmark"
+            }
+          ],
+          "availability_zone": "nova",
+          "os-vol-host-attr:host": "difleming@lvmdriver-1#lvmdriver-1",
+          "encrypted": false,
+          "os-volume-replication:extended_status": null,
+          "replication_status": "disabled",
+          "snapshot_id": null,
+          "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+          "size": 2,
+          "user_id": "32779452fcd34ae1a53a797ac8a1e064",
+          "os-vol-tenant-attr:tenant_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
+          "os-vol-mig-status-attr:migstat": null,
+          "metadata": {
+            "readonly": "False",
+            "attached_mode": "rw"
+          },
+          "status": "in-use",
+          "description": null,
+          "multiattach": true,
+          "os-volume-replication:driver_data": null,
+          "source_volid": null,
+          "consistencygroup_id": null,
+          "os-vol-mig-status-attr:name_id": null,
+          "name": "test-volume-attachments",
+          "bootable": "false",
+          "created_at": "2015-11-29T03:01:44.000000",
+          "volume_type": "lvmdriver-1"
         }
       ]
     }}

--- a/test/unit/volume_connection_test.rb
+++ b/test/unit/volume_connection_test.rb
@@ -90,6 +90,113 @@ class VolumeConnectionTest < Test::Unit::TestCase
     assert_equal types[0][:id], 'b3a104b6-fe70-4450-8681-e911a153f41f'
   end
 
+  def test_list_volumes
+    json_response = %{{
+      "volumes": [
+        {
+            "id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+            "display_name": "vol-001",
+            "display_description": "Another volume.",
+            "status": "active",
+            "size": 30,
+            "volume_type": "289da7f8-6440-407c-9fb4-7db01ec49164",
+            "metadata": {
+                "contents": "junk"
+            },
+            "availability_zone": "us-east1",
+            "snapshot_id": null,
+            "attachments": [
+                {
+                    "attachment_id": "03987cd1-0ad5-40d1-9b2a-7cc48295d4fa",
+                    "id": "47e9ecc5-4045-4ee3-9a4b-d859d546a0cf",
+                    "volume_id": "6c80f8ac-e3e2-480c-8e6e-f1db92fe4bfe",
+                    "server_id": "d1c4788b-9435-42e2-9b81-29f3be1cd01f",
+                    "host_name": "mitaka",
+                    "device": "/"
+                }
+            ],
+            "created_at": "2012-02-14T20:53:07Z"
+        }
+      ]
+    }}
+
+    response = mock
+    response.stubs(code: '200', body: json_response)
+    @cinder.connection.stubs(:req).returns(response)
+
+    volumes = @cinder.list_volumes(limit: 1)
+    assert_equal volumes.size , 1
+    assert_equal volumes[0].id, '521752a6-acf6-4b2d-bc7a-119f9148cd8c'
+    assert_equal volumes[0].display_name, 'vol-001'
+    assert_equal volumes[0].status, 'active'
+  end
+
+  def test_list_volumes_detail
+    json_response = %{{
+      "volumes": [
+        {
+            "migration_status": null,
+            "attachments": [
+                {
+                    "server_id": "f4fda93b-06e0-4743-8117-bc8bcecd651b",
+                    "attachment_id": "3b4db356-253d-4fab-bfa0-e3626c0b8405",
+                    "host_name": null,
+                    "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                    "device": "/dev/vdb",
+                    "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38"
+                }
+            ],
+            "links": [
+                {
+                    "href": "http://23.253.248.171:8776/v2/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                    "rel": "self"
+                },
+                {
+                    "href": "http://23.253.248.171:8776/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                    "rel": "bookmark"
+                }
+            ],
+            "availability_zone": "nova",
+            "os-vol-host-attr:host": "difleming@lvmdriver-1#lvmdriver-1",
+            "encrypted": false,
+            "os-volume-replication:extended_status": null,
+            "replication_status": "disabled",
+            "snapshot_id": null,
+            "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+            "size": 2,
+            "user_id": "32779452fcd34ae1a53a797ac8a1e064",
+            "os-vol-tenant-attr:tenant_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
+            "os-vol-mig-status-attr:migstat": null,
+            "metadata": {
+                "readonly": "False",
+                "attached_mode": "rw"
+            },
+            "status": "in-use",
+            "description": null,
+            "multiattach": true,
+            "os-volume-replication:driver_data": null,
+            "source_volid": null,
+            "consistencygroup_id": null,
+            "os-vol-mig-status-attr:name_id": null,
+            "name": "test-volume-attachments",
+            "bootable": "false",
+            "created_at": "2015-11-29T03:01:44.000000",
+            "volume_type": "lvmdriver-1"
+        }
+      ]
+    }}
+
+    response = mock
+    response.stubs(code: '200', body: json_response)
+    @cinder.connection.stubs(:req).returns(response)
+
+    volumes = @cinder.list_volumes_detail(limit: 1)
+    assert_equal volumes.size , 1
+    assert_equal volumes[0]["attachments"][0]["volume_id"] , "6edbc2f4-1507-44f8-ac0d-eed1d2608d38"
+    assert_equal volumes[0]["status"] , "in-use"
+    assert_equal volumes[0]["volume_type"] , "lvmdriver-1"
+  end
+
   def test_get_quotas
     json_response = %{{
       "quota_set": {


### PR DESCRIPTION
I added force_delete! and list_volumes_detail
and compute method lock and unlock.

POST /v2.1/​{tenant_id}​/servers/​{server_id}​/action

```
Force-delete server (forceDelete action)
Force-deletes a server before deferred cleanup.
```

GET /v2/​{tenant_id}​/volumes/detail

http://developer.openstack.org/api-ref-blockstorage-v2.html