### PR TITLE
gateway typo fix

### DIFF
--- a/lib/openstack/network/router.rb
+++ b/lib/openstack/network/router.rb
@@ -14,7 +14,7 @@ module Network
     def initialize(router_info={})
       @name = router_info['name']
       @status = router_info['status']
-      @external_geteway_info = router_info['external_gateway_info']
+      @external_gateway_info = router_info['external_gateway_info']
       @admin_state_up = router_info['admin_state_up']
       @tenant_ip = router_info['tenant_ip']
       @id = router_info['id']


### PR DESCRIPTION
attr_reader :external_gateway_info


Now, you can't access external_gateway_info because of this typo.
