### PR TITLE
fix the buffer issues

### DIFF
--- a/lib/openstack/swift/connection.rb
+++ b/lib/openstack/swift/connection.rb
@@ -170,11 +170,11 @@ module Swift
 
     #for ruby 2.x
     def read(length, buffer=nil)
-      chunk = @file.read(length)
-
-      return nil if chunk.nil?
-      buffer << chunk if buffer
-
+      if buffer.nil?
+        chunk = @file.read(length)
+      else
+        chunk = @file.read(length, buffer)
+      end
       chunk
     end
 


### PR DESCRIPTION
This is a fix for the way that we're reading the chunks into the buffer in ruby 2.x.

The current method causes issues where the buffer is reset and file uploads are corrupted.

The fix is to read directly into the buffer.