### PR TITLE
Fix method error in put_object when debug

### DIFF
--- a/lib/openstack/connection.rb
+++ b/lib/openstack/connection.rb
@@ -144,7 +144,7 @@ class Connection
       start_http(server,path,port,scheme,hdrhash)
       response = @http[server].request(request)
       if @is_debug
-          puts "REQUEST: #{method} => #{path}"
+          puts "REQUEST: PUT => #{path}"
           puts data if data
           puts "RESPONSE: #{response.body}"
           puts '----------------------------------------'


### PR DESCRIPTION
There is no `method` method in `put_object` when I enabled is_debug option, So fixed it.