### PR TITLE
Fixes #84 

### DIFF
--- a/lib/openstack/swift/connection.rb
+++ b/lib/openstack/swift/connection.rb
@@ -169,7 +169,7 @@ module Swift
     end
 
     #for ruby 2.x
-    def read(length, buffer=nil)
+    def read(length=nil, buffer=nil)
       if buffer.nil?
         chunk = @file.read(length)
       else


### PR DESCRIPTION
Testing with `unit/test` and [webmock](https://github.com/bblimke/webmock) in my program fails when pushing object with `container.create_object`:

```
wrong number of arguments (0 for 1..2) in lib/openstack/swift/connection.rb:172:in `read'
```

I faced the same bug reported by @z5h in #84. 
This PR fixes the problem for my tests and do not break `create_object`.
