### PR TITLE
Add missing URI encoding in swift object_metadata method

### DIFF
--- a/lib/openstack/swift/storage_object.rb
+++ b/lib/openstack/swift/storage_object.rb
@@ -70,7 +70,7 @@ module Swift
     #
     def object_metadata
       path = "/#{@containername}/#{@name}"
-      response = @container.swift.connection.req("HEAD", path)
+      response = @container.swift.connection.req("HEAD", URI.encode(path))
       resphash = response.to_hash
       meta = { :bytes=>resphash["content-length"][0],
                :content_type=>resphash["content-type"][0],


### PR DESCRIPTION
This fix API error when retrieving object_metadata with special characters in used.