### PR TITLE
Fix some connection failed messages include `Net::HTTP` object.

### DIFF
--- a/lib/openstack/connection.rb
+++ b/lib/openstack/connection.rb
@@ -365,7 +365,7 @@ class Connection
         puts "Can't connect to the server: #{tries} tries  to reconnect" if connection.is_debug
         sleep time += 1
         retry unless (tries -= 1) <= 0
-        raise OpenStack::Exception::Connection, "Unable to connect to #{server}"
+        raise OpenStack::Exception::Connection, "Unable to connect to #{connection.proxy_host}"
       end
 
       response = server.get(connection.auth_path, hdrhash)
@@ -420,7 +420,7 @@ class Connection
         puts "Can't connect to the server: #{tries} tries  to reconnect" if connection.is_debug
         sleep time += 1
         retry unless (tries -= 1) <= 0
-        raise OpenStack::Exception::Connection, "Unable to connect to  #{server}"
+        raise OpenStack::Exception::Connection, "Unable to connect to  #{connection.proxy_host}"
       end
 
       @uri = String.new
@@ -532,7 +532,7 @@ class Connection
         puts "Can't connect to the server: #{tries} tries to reconnect" if connection.is_debug
         sleep time += 1
         retry unless (tries -= 1) <= 0
-        raise OpenStack::Exception::Connection, "Unable to connect to #{server}"
+        raise OpenStack::Exception::Connection, "Unable to connect to #{connection.proxy_host}"
       end
 
       # Build Auth JSON


### PR DESCRIPTION
```ruby
> OpenStack::Connection.create username: "foo", api_key: "foo", auth_url: "http://localhost:0"
=> Unable to connect to #<Net::HTTP:0x0000562da4c902c0> (OpenStack::Exception::Connection)
```