### PR TITLE
Switch from the obsolete URI.encode to CGI.escape to fix warnings

### DIFF
--- a/lib/openstack/compute/server.rb
+++ b/lib/openstack/compute/server.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module OpenStack
 module Compute
   class Server
@@ -52,7 +54,7 @@ module Compute
     #  >> server.refresh
     #  => true
     def populate(data=nil)
-      path = "/servers/#{URI.encode(@id.to_s)}"
+      path = "/servers/#{CGI.escape(@id.to_s)}"
       if data.nil? then
           response = @compute.connection.req("GET", path)
           OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
@@ -113,7 +115,7 @@ module Compute
       OpenStack::Exception.raise_exception(response) unless response.code.match(/^20.$/)
       true
     end
-    
+
     # Sends an API request to start (resume) the server.
     #
     # Returns true if the API call succeeds.


### PR DESCRIPTION
Fixes the following warning:

```
/Users/ryan/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/openstack-3.3.21/lib/openstack/compute/server.rb:56: warning: URI.escape is obsolete
```

I think this method was marked obsolete a while ago and doesn't seem to be going anywhere, but I thought I'd send a PR anyway, thanks for your consideration!